### PR TITLE
fix: pin npm to specific version in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -154,6 +154,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.7.0
 
       - run: npm publish

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -154,6 +154,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install npm
-        run: npm install -g npm@11.7.0
+        run: npm install -g github:npm/cli#6d1db8724b1d0e5457a87bb31e62e43d566348ce # npm@11.7.0
 
       - run: npm publish


### PR DESCRIPTION
## Summary
Pin `npm@latest` to `npm@11.7.0` in the create-release workflow to prevent automatically pulling compromised versions of npm or its dependencies.

## What changed
- `.github/workflows/create-release.yaml`: Changed `npm install -g npm@latest` to `npm install -g npm@11.7.0`

## Motivation
The [axios npm supply chain compromise (2026-03-30)](https://github.com/nicedayzhu/axios) demonstrated the risk of using unpinned `@latest` tags in CI pipelines. An attacker who publishes a malicious version to npm can immediately compromise any workflow that installs `@latest`. Pinning to a known-good version eliminates this attack vector.

## Test plan
- [ ] Verify the create-release workflow still runs successfully with the pinned npm version
- [ ] Confirm `npm@11.7.0` is a valid, uncompromised release

🤖 Generated with [Claude Code](https://claude.com/claude-code)